### PR TITLE
[ADD] Added `extract_milestone_pr_infos` for adding pr infos in release ticket

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     required: false
     description: 'Input changelog file name. (e.g. CHANGELOG_KTX_DRAFT.md) Default is CHANGELOG_DRAFT.md.'
     default: 'CHANGELOG_DRAFT.md'
+  extract_milestone_pr_infos:
+    required: false
+    description: 'If you want to extract the merged PR information from the milestone of relaese PR and add it to the release ticket, input the value `true`.'
+    default: 'false'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -138,7 +138,8 @@ async function buildCreateTicketParams(
       release_version,
       core.getInput('framework').toLowerCase()
     ),
-    changelog_file: core.getInput('changelog_file') || 'CHANGELOG_DRAFT.md'
+    changelog_file: core.getInput('changelog_file') || 'CHANGELOG_DRAFT.md',
+    extract_milestone_pr_infos: core.getBooleanInput('extract_milestone_pr_infos') || false
   }
 }
 


### PR DESCRIPTION
milestone 에 포함된 PR 정보들을 배포티켓에 추가하기 위한 trigger flag 입니다.