### PR TITLE
fix: upgrade js-yaml to 4.3.0 / 3.15.0 (CVE-2026-59869)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,17 +2514,17 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

- Upgrade `js-yaml` to address [CVE-2026-59869](https://nvd.nist.gov/vuln/detail/CVE-2026-59869) (High)
- `js-yaml@^4.1.0` 4.1.0 → **4.3.0** (direct devDependency)
- `js-yaml@^3.13.1` 3.14.1 → **3.15.0** (transitive via `@istanbuljs/load-nyc-config`)
- Only `yarn.lock` updated — no `package.json` / `resolutions` changes needed

## Details

**Vulnerability**: A YAML document with a chain of mappings that each merge the previous one via the merge key (`<<`) makes js-yaml spend quadratic CPU time on input that grows only linearly — a denial of service.

**Fix**: The advisory has two patch lines — `>= 3.0.0, < 3.15.0` is fixed in **3.15.0**, and `>= 4.0.0, < 4.3.0` is fixed in **4.3.0**. Both resolved versions satisfy their existing semver ranges, so re-resolving the lockfile was sufficient; no `resolutions` entry was needed.

Note: the Jira ticket only lists 4.3.0 as the recommended fix, but the 3.14.1 instance at `yarn.lock:2516` also falls in the vulnerable 3.x range, so it is bumped to 3.15.0 in the same change.

## Verification

- `yarn install --frozen-lockfile` — lockfile is consistent
- `yarn build` (`tsc` + `ncc build`) — passes, and the regenerated `dist/` is byte-identical to what is committed (no `dist` diff)
- `yarn test` — 7/7 passing
- `yarn format-check` — passes

## References

- Jira: [SECURE-4142](https://sendbird.atlassian.net/browse/SECURE-4142)
- Advisory: [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)
- CVE: [CVE-2026-59869](https://nvd.nist.gov/vuln/detail/CVE-2026-59869)


[SECURE-4142]: https://sendbird.atlassian.net/browse/SECURE-4142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ